### PR TITLE
War machines squashed commit (2)

### DIFF
--- a/battle-gui/src/main/java/pl/psi/gui/MainBattleController.java
+++ b/battle-gui/src/main/java/pl/psi/gui/MainBattleController.java
@@ -1,5 +1,6 @@
 package pl.psi.gui;
 
+import pl.psi.MapObjectIf;
 import pl.psi.GameEngine;
 import pl.psi.Hero;
 import pl.psi.Point;
@@ -9,7 +10,6 @@ import javafx.scene.control.Button;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.GridPane;
 import javafx.scene.paint.Color;
-import pl.psi.creatures.Creature;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -44,10 +44,11 @@ public class MainBattleController implements PropertyChangeListener
             for( int y = 0; y < 10; y++ )
             {
                 Point currentPoint = new Point( x, y );
-                Optional< Creature > creature = gameEngine.getCreature( currentPoint );
+                Optional<MapObjectIf> gameObject = gameEngine.getMapObject( currentPoint );
                 final MapTile mapTile = new MapTile( "" );
-                creature.ifPresent( c -> mapTile.setName( c.toString() ) );
-                if( gameEngine.isCurrentCreature( currentPoint ) )
+                gameObject.ifPresent( c -> mapTile.setName( c.toString() ) );
+
+                if( gameEngine.isCurrentMapObject( currentPoint ) )
                 {
                     mapTile.setBackground( Color.GREENYELLOW );
                 }
@@ -60,9 +61,11 @@ public class MainBattleController implements PropertyChangeListener
                 }
                 if( gameEngine.canAttack( currentPoint ) )
                 {
-                    mapTile.setBackground( Color.RED );
+                    mapTile.setBackground( Color.INDIANRED );
                     mapTile.addEventHandler( MouseEvent.MOUSE_CLICKED, ( e ) -> {
-                        gameEngine.attack( currentPoint );
+                        gameEngine.performAction(currentPoint);
+                        //gameEngine.attack( currentPoint );
+                        //gameEngine.heal(currentPoint);
                     } );
                 }
                 gridMap.add( mapTile, x, y );

--- a/battle-gui/src/main/java/pl/psi/gui/MapTile.java
+++ b/battle-gui/src/main/java/pl/psi/gui/MapTile.java
@@ -1,5 +1,6 @@
 package pl.psi.gui;
 
+import javafx.geometry.Pos;
 import javafx.scene.control.Label;
 import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
@@ -15,9 +16,14 @@ class MapTile extends StackPane
     {
         rect = new Rectangle( 60, 60 );
         rect.setFill( Color.WHITE );
-        rect.setStroke( Color.RED );
+        rect.setStroke( Color.BLACK );
         getChildren().add( rect );
         label = new Label( aName );
+        label.setAlignment(Pos.CENTER);
+        label.setWrapText(true);
+        label.setMaxWidth(rect.getWidth() - 10);
+        label.setMaxHeight(rect.getHeight());
+
         getChildren().add( label );
     }
 

--- a/battle-gui/src/main/java/pl/psi/gui/Start.java
+++ b/battle-gui/src/main/java/pl/psi/gui/Start.java
@@ -3,12 +3,15 @@ package pl.psi.gui;
 import java.io.IOException;
 import java.util.List;
 
+import pl.psi.warmachines.WarMachine;
+import WarMachines.WarMachineStatistic;
 import pl.psi.Hero;
 
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
+import pl.psi.creatures.Creature;
 import pl.psi.creatures.NecropolisFactory;
 
 public class Start extends Application
@@ -48,13 +51,20 @@ public class Start extends Application
 
     private Hero createP2()
     {
-        final Hero ret = new Hero( List.of( new NecropolisFactory().create( true, 1, 5 ) ) );
+        Creature creature1 = new NecropolisFactory().create( false, 1, 2);
+        WarMachine warMachine1 = new WarMachine.Builder().statistic(WarMachineStatistic.CATAPULT).amount(1).build();
+
+        final Hero ret = new Hero(List.of(creature1), List.of(warMachine1));
         return ret;
     }
 
     private Hero createP1()
     {
-        final Hero ret = new Hero( List.of( new NecropolisFactory().create( false, 1, 5 ) ) );
+        Creature creature1 = new NecropolisFactory().create( false, 2, 1);
+        WarMachine warMachine1 = new WarMachine.Builder().statistic(WarMachineStatistic.BALLISTA).amount(1).build();
+        WarMachine warMachine2 = new WarMachine.Builder().statistic(WarMachineStatistic.FIRST_AID_TENT).amount(1).build();
+
+        final Hero ret = new Hero(List.of(creature1), List.of(warMachine1, warMachine2));
         return ret;
     }
 

--- a/battle-model/src/main/java/pl/psi/Board.java
+++ b/battle-model/src/main/java/pl/psi/Board.java
@@ -6,58 +6,64 @@ import java.util.Optional;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 
-import pl.psi.creatures.Creature;
-
 /**
  * TODO: Describe this class (The first line - until the first dot - will interpret as the brief description).
  */
 public class Board
 {
     private static final int MAX_WITDH = 14;
-    private final BiMap< Point, Creature > map = HashBiMap.create();
+    private final BiMap< Point, MapObjectIf> map = HashBiMap.create();
 
-    public Board( final List< Creature > aCreatures1, final List< Creature > aCreatures2 )
+    public Board( final List< MapObjectIf > mapObjectIfs1, final List< MapObjectIf > mapObjectIfs2 )
     {
-        addCreatures( aCreatures1, 0 );
-        addCreatures( aCreatures2, MAX_WITDH );
+        addMapObject( mapObjectIfs1, 3 );
+        addMapObject( mapObjectIfs2, 11 );
     }
 
-    private void addCreatures( final List< Creature > aCreatures, final int aXPosition )
+    private void addMapObject(final List< MapObjectIf > mapObjectIfs, final int aXPosition )
     {
-        for( int i = 0; i < aCreatures.size(); i++ )
+        for( int i = 0; i < mapObjectIfs.size(); i++ )
         {
-            map.put( new Point( aXPosition, i * 2 + 1 ), aCreatures.get( i ) );
+            map.put( new Point( aXPosition, i * 2 + 1 ), mapObjectIfs.get( i ) );
         }
     }
 
-    Optional< Creature > getCreature( final Point aPoint )
+    public void removeMapObject(MapObjectIf mapObjectIf ){
+        map.remove(getPosition(mapObjectIf));
+    }
+
+    Optional< MapObjectIf > getMapObject(final Point aPoint )
     {
         return Optional.ofNullable( map.get( aPoint ) );
     }
 
-    void move( final Creature aCreature, final Point aPoint )
+    void move( final MapObjectIf mapObjectIf, final Point aPoint )
     {
-        if( canMove( aCreature, aPoint ) )
+        if( canMove( mapObjectIf, aPoint ) )
         {
             map.inverse()
-                .remove( aCreature );
-            map.put( aPoint, aCreature );
+                .remove( mapObjectIf );
+            map.put( aPoint, mapObjectIf );
         }
     }
 
-    boolean canMove( final Creature aCreature, final Point aPoint )
+    boolean canMove( final MapObjectIf mapObjectIf, final Point aPoint )
     {
         if( map.containsKey( aPoint ) )
         {
             return false;
         }
-        final Point oldPosition = getPosition( aCreature );
-        return aPoint.distance( oldPosition.getX(), oldPosition.getY() ) < aCreature.getMoveRange();
+        final Point oldPosition = getPosition( mapObjectIf );
+        return aPoint.distance( oldPosition.getX(), oldPosition.getY() ) < mapObjectIf.getMoveRange();
     }
 
-    Point getPosition( Creature aCreature )
+    Point getPosition( MapObjectIf mapObjectIf )
     {
-        return map.inverse()
-            .get( aCreature );
+        if ((map.inverse().get( mapObjectIf )) != null){
+            return map.inverse()
+                    .get( mapObjectIf );
+        } else{
+            return new Point(0,0);
+        }
     }
 }

--- a/battle-model/src/main/java/pl/psi/GameEngine.java
+++ b/battle-model/src/main/java/pl/psi/GameEngine.java
@@ -2,9 +2,9 @@ package pl.psi;
 
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
-
-import pl.psi.creatures.Creature;
 
 /**
  * TODO: Describe this class (The first line - until the first dot - will interpret as the brief description).
@@ -12,33 +12,81 @@ import pl.psi.creatures.Creature;
 public class GameEngine {
 
     public static final String CREATURE_MOVED = "CREATURE_MOVED";
-    private final TurnQueue turnQueue;
     private final Board board;
     private final PropertyChangeSupport observerSupport = new PropertyChangeSupport(this);
+    private final TurnQueue turnQueue;
+    private List<MapObjectIf> mapObjectIf1 = null;
+    private List<MapObjectIf> mapObjectIf2 = null;
 
     public  GameEngine(final Hero aHero1, final Hero aHero2) {
-        turnQueue = new TurnQueue(aHero1.getCreatures(), aHero2.getCreatures());
-        board = new Board(aHero1.getCreatures(), aHero2.getCreatures());
+        List<MapObjectIf> mapObjectIf1 = new ArrayList<>();
+        mapObjectIf1.addAll(aHero1.getCreatures());
+        mapObjectIf1.addAll(aHero1.getWarMachines());
+
+        List<MapObjectIf> mapObjectIf2 = new ArrayList<>();
+        mapObjectIf2.addAll(aHero2.getCreatures());
+        mapObjectIf2.addAll(aHero2.getWarMachines());
+
+        turnQueue = new TurnQueue(mapObjectIf1, mapObjectIf2);
+        board = new Board(mapObjectIf1, mapObjectIf2);
     }
 
     public void attack(final Point point) {
-        board.getCreature(point)
-                .ifPresent(defender -> turnQueue.getCurrentCreature()
-                        .attack(defender));
+        board.getMapObject(point)
+                .ifPresent(defender -> {
+                    try {
+                        turnQueue.getCurrentMapObject()
+                                .attack(defender);
+                        checkIfAlive(defender);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
         pass();
     }
 
+    public void heal(final Point point) {
+
+        board.getMapObject(point)
+                .ifPresent(comrade -> {
+                    try {
+                        turnQueue.getCurrentMapObject()
+                                .heal(comrade);
+                        checkIfAlive(comrade);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+        pass();
+    }
+
+    public void performAction(final Point point){
+        if(turnQueue.getCurrentMapObject().getName().equals("First Aid Tent")){
+            heal(point);
+        }else {
+            attack(point);
+        }
+    }
+
+    private void checkIfAlive(MapObjectIf defender) {
+        if(!(turnQueue.getCurrentMapObject().checkIfAlive(defender))){
+            board.removeMapObject(defender);
+            turnQueue.removeMapObject(defender);
+            pass();
+        }
+    }
+
     public boolean canMove(final Point aPoint) {
-        return board.canMove(turnQueue.getCurrentCreature(), aPoint);
+        return board.canMove(turnQueue.getCurrentMapObject(), aPoint);
     }
 
     public void move(final Point aPoint) {
-        board.move(turnQueue.getCurrentCreature(), aPoint);
+        board.move(turnQueue.getCurrentMapObject(), aPoint);
         observerSupport.firePropertyChange(CREATURE_MOVED, null, aPoint);
     }
 
-    public Optional<Creature> getCreature(final Point aPoint) {
-        return board.getCreature(aPoint);
+    public Optional<MapObjectIf> getMapObject(final Point aPoint) {
+        return board.getMapObject(aPoint);
     }
 
     public void pass() {
@@ -51,14 +99,22 @@ public class GameEngine {
     }
 
     public boolean canAttack(final Point point) {
-        double distance = board.getPosition(turnQueue.getCurrentCreature())
+        double distance = board.getPosition(turnQueue.getCurrentMapObject())
                 .distance(point);
-        return board.getCreature(point)
-                .isPresent()
-                && distance < 2 && distance > 0;
+        boolean canAttackFromDistance = turnQueue.getCurrentMapObject().canAttackFromDistance();
+        if(canAttackFromDistance){
+            return board.getMapObject(point)
+                    .isPresent()
+                    && distance <= 14 && distance > 0;
+        } else {
+            return board.getMapObject(point)
+                    .isPresent()
+                    && distance < 2 && distance > 0;
+        }
+
     }
 
-    public boolean isCurrentCreature(Point aPoint) {
-        return Optional.of(turnQueue.getCurrentCreature()).equals(board.getCreature(aPoint));
+    public boolean isCurrentMapObject(Point aPoint) {
+        return Optional.of(turnQueue.getCurrentMapObject()).equals(board.getMapObject(aPoint));
     }
 }

--- a/battle-model/src/main/java/pl/psi/Hero.java
+++ b/battle-model/src/main/java/pl/psi/Hero.java
@@ -2,6 +2,7 @@ package pl.psi;
 
 import java.util.List;
 
+import pl.psi.warmachines.WarMachine;
 import pl.psi.creatures.Creature;
 
 import lombok.Getter;
@@ -12,10 +13,13 @@ import lombok.Getter;
 public class Hero
 {
     @Getter
-    private final List< Creature > creatures;
+    private final List<Creature> creatures;
+    @Getter
+    private final List<WarMachine> warMachines;
 
-    public Hero( final List< Creature > aCreatures )
+    public Hero( final List< Creature > aCreatures, final List<WarMachine> aWarMachine)
     {
         creatures = aCreatures;
+        warMachines = aWarMachine;
     }
 }

--- a/battle-model/src/main/java/pl/psi/MapObjectIf.java
+++ b/battle-model/src/main/java/pl/psi/MapObjectIf.java
@@ -1,0 +1,39 @@
+package pl.psi;
+
+//import pl.psi.creatures.Creature;
+
+import java.beans.PropertyChangeListener;
+
+public interface MapObjectIf extends PropertyChangeListener {
+    int getCurrentHp();
+
+    void attack(MapObjectIf defender) throws Exception;
+
+    void heal(MapObjectIf comrade) throws Exception;
+
+    boolean checkIfAlive(MapObjectIf defender);
+
+    int getMaxHp();
+
+    void setCurrentHp(int max);
+    String getName();
+
+
+
+    int getMoveRange();
+
+    boolean canAttackFromDistance();
+
+//    void attack(final Point point);
+//
+//    boolean canMove(final Point point);
+//
+//    boolean canAttack(final Point point);
+//    Optional<Creature> getCreature(final Point point);
+//
+//    boolean isCurrentCreature(Point point);
+
+
+
+}
+

--- a/battle-model/src/main/java/pl/psi/TurnQueue.java
+++ b/battle-model/src/main/java/pl/psi/TurnQueue.java
@@ -5,10 +5,9 @@ import java.beans.PropertyChangeSupport;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Queue;
+import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import pl.psi.creatures.Creature;
 
 /**
  * TODO: Describe this class (The first line - until the first dot - will interpret as the brief description).
@@ -16,38 +15,46 @@ import pl.psi.creatures.Creature;
 public class TurnQueue {
 
     public static final String END_OF_TURN = "END_OF_TURN";
-    public static final String NEXT_CREATURE = "NEXT_CREATURE";
-    private final Collection<Creature> creatures;
-    private final Queue<Creature> creaturesQueue;
+    public static final String NEXT_MAP_OBJECT = "NEXT_CREATURE";
     private final PropertyChangeSupport observerSupport = new PropertyChangeSupport(this);
-    private Creature currentCreature;
+    private final Collection<MapObjectIf> mapObjectIfs;
+    private MapObjectIf currentMapObject;
+    private final Queue<MapObjectIf> mapObjectsQueue;
     private int roundNumber;
 
-    public TurnQueue(final Collection<Creature> aCreatureList,
-                     final Collection<Creature> aCreatureList2) {
-        creatures = Stream.concat(aCreatureList.stream(), aCreatureList2.stream())
+    public TurnQueue(final Collection<MapObjectIf> aMapObjectList1,
+                     final Collection<MapObjectIf> aMapObjectList2) {
+        mapObjectIfs = Stream.concat(aMapObjectList1.stream(), aMapObjectList2.stream())
                 .collect(Collectors.toList());
-        creaturesQueue = new LinkedList<>();
+        mapObjectsQueue = new LinkedList<>();
         initQueue();
-        creatures.forEach(observerSupport::addPropertyChangeListener);
+        mapObjectIfs.forEach(observerSupport::addPropertyChangeListener);
         next();
     }
 
     private void initQueue() {
-        creaturesQueue.addAll(creatures);
+        mapObjectsQueue.addAll(mapObjectIfs);
     }
 
-    public Creature getCurrentCreature() {
-        return currentCreature;
+    public MapObjectIf getCurrentMapObject() {
+        return currentMapObject;
+    }
+
+    public MapObjectIf getRandomMapObject() {
+        MapObjectIf[] array = mapObjectIfs.toArray(new MapObjectIf[0]);
+        Random random = new Random();
+        int randomIndex = random.nextInt(array.length);
+        return array[randomIndex];
     }
 
     public void next() {
-        Creature oldCreature = currentCreature;
-        if (creaturesQueue.isEmpty()) {
+        MapObjectIf oldMapObject = currentMapObject;
+
+        if (mapObjectsQueue.isEmpty()) {
             endOfTurn();
         }
-        currentCreature = creaturesQueue.poll();
-        observerSupport.firePropertyChange(NEXT_CREATURE, oldCreature, currentCreature);
+        currentMapObject = mapObjectsQueue.poll();
+        observerSupport.firePropertyChange(NEXT_MAP_OBJECT, oldMapObject, currentMapObject);
     }
 
     private void endOfTurn() {
@@ -58,5 +65,9 @@ public class TurnQueue {
 
     void addObserver(PropertyChangeListener aObserver) {
         observerSupport.addPropertyChangeListener(aObserver);
+    }
+
+    public void removeMapObject(MapObjectIf mapObjectIf){
+        mapObjectIfs.remove(mapObjectIf);
     }
 }

--- a/battle-model/src/main/java/pl/psi/creatures/Creature.java
+++ b/battle-model/src/main/java/pl/psi/creatures/Creature.java
@@ -10,6 +10,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Random;
 
+import pl.psi.MapObjectIf;
 import lombok.Setter;
 import pl.psi.TurnQueue;
 
@@ -21,7 +22,7 @@ import lombok.Getter;
  * TODO: Describe this class (The first line - until the first dot - will interpret as the brief description).
  */
 @Getter
-public class Creature implements PropertyChangeListener {
+public class Creature implements PropertyChangeListener, MapObjectIf {
     private CreatureStatisticIf stats;
     @Setter
     private int amount;
@@ -73,7 +74,7 @@ public class Creature implements PropertyChangeListener {
         return stats.getMaxHp();
     }
 
-    protected void setCurrentHp(final int aCurrentHp) {
+     public void setCurrentHp(final int aCurrentHp) {
         currentHp = aCurrentHp;
     }
 
@@ -117,6 +118,26 @@ public class Creature implements PropertyChangeListener {
 
     public int getMoveRange() {
         return stats.getMoveRange();
+    }
+
+    @Override
+    public boolean canAttackFromDistance() {
+        return false;
+    }
+
+    @Override
+    public void attack(MapObjectIf defender) throws Exception {
+        System.out.println("Creature is attacking");
+    }
+
+    @Override
+    public void heal(MapObjectIf comrade) throws Exception {
+
+    }
+
+    @Override
+    public boolean checkIfAlive(MapObjectIf defender) {
+        return true;
     }
 
     public static class Builder {

--- a/battle-model/src/main/java/pl/psi/creatures/DamageCalculatorIf.java
+++ b/battle-model/src/main/java/pl/psi/creatures/DamageCalculatorIf.java
@@ -3,4 +3,5 @@ package pl.psi.creatures;
 public interface DamageCalculatorIf
 {
     int calculateDamage( Creature aAttacker, Creature aDefender );
+//    int calculateDamege(WarMachine aAttacker, WarMachine aDefender);
 }

--- a/battle-model/src/main/java/pl/psi/creatures/SelfHealAfterTurnCreature.java
+++ b/battle-model/src/main/java/pl/psi/creatures/SelfHealAfterTurnCreature.java
@@ -75,7 +75,7 @@ class SelfHealAfterTurnCreature extends Creature {
     }
 
     @Override
-    protected void setCurrentHp(int aCurrentHp) {
+    public void setCurrentHp(int aCurrentHp) {
         decorated.setCurrentHp(aCurrentHp);
     }
 

--- a/battle-model/src/main/java/pl/psi/warmachines/FirstAidTentIf.java
+++ b/battle-model/src/main/java/pl/psi/warmachines/FirstAidTentIf.java
@@ -1,0 +1,7 @@
+package pl.psi.warmachines;
+
+import pl.psi.MapObjectIf;
+
+public interface FirstAidTentIf {
+    int calculateHealPoint(WarMachine aAttacker, MapObjectIf aComrade, int currentHP) throws Exception;
+}

--- a/battle-model/src/main/java/pl/psi/warmachines/WarMachine.java
+++ b/battle-model/src/main/java/pl/psi/warmachines/WarMachine.java
@@ -1,0 +1,162 @@
+package pl.psi.warmachines;
+
+import WarMachines.WarMachineStatisticIf;
+import com.google.common.collect.Range;
+import lombok.Getter;
+import lombok.Setter;
+import pl.psi.MapObjectIf;
+//import pl.psi.TurnQueue;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+@Getter
+public class WarMachine implements PropertyChangeListener, MapObjectIf {
+    private WarMachineDamageCalculatorIF calculator;
+    private FirstAidTentIf HPcalculator;
+    private WarMachineStatisticIf stats;
+    @Setter
+    private int amount;
+    private int currentHp;
+
+    WarMachine(){
+
+    }
+
+    WarMachine(final WarMachineStatisticIf aStats,
+               final WarMachineDamageCalculatorIF aCalculator,
+               final FirstAidTentIf aHPcalculator,
+               final int aAmount) {
+        stats = aStats;
+        amount = aAmount;
+        currentHp = stats.getMaxHp();
+        calculator = aCalculator;
+        HPcalculator = aHPcalculator;
+    }
+
+    public void attack(final MapObjectIf aDefender) throws Exception {
+        if (isAlive()) {
+            final int damage = getCalculator().calculateDamage(this, aDefender);
+            applyDamage(aDefender, damage);
+        }
+    }
+
+    public void heal(MapObjectIf aComrade) throws Exception {
+        if (isAlive()) {
+            final int hp = getHPcalculator().calculateHealPoint(this, aComrade, aComrade.getCurrentHp());
+            aComrade.setCurrentHp(hp);
+            if ((aComrade.getCurrentHp() > aComrade.getMaxHp())){
+                aComrade.setCurrentHp(aComrade.getMaxHp());
+            }
+        }
+    }
+
+    public boolean isAlive() {
+        return getAmount() > 0;
+    }
+
+    private void applyDamage(final MapObjectIf aDefender, final int aDamage) {
+        int hpToSubtract = aDamage % aDefender.getMaxHp();
+//        int amountToSubtract = Math.round((float) aDamage / aDefender.getMaxHp());
+
+        int hp = aDefender.getCurrentHp() - hpToSubtract;
+        //            System.out.println("HP: " + hp);
+        //            System.out.println("War Machine is dead");
+        //            aDefender.setAmount(aDefender.getAmount() - 1);
+        aDefender.setCurrentHp(Math.max(hp, 0));
+//        aDefender.setAmount(aDefender.getAmount() - amountToSubtract);
+    }
+
+    public int getMaxHp() {
+        return stats.getMaxHp();
+    }
+
+    public void setCurrentHp(final int aCurrentHp) {
+        currentHp = aCurrentHp;
+    }
+
+    @Override
+    public int getMoveRange() {
+        return 0;
+    }
+
+    @Override
+    public boolean canAttackFromDistance() {
+        return true;
+    }
+
+
+    Range<Integer> getDamage() {
+        return stats.getDamage();
+    }
+
+    int getAttack() {
+        return stats.getAttack();
+    }
+
+    int getArmor() {
+        return stats.getArmor();
+    }
+
+//    @Override
+//    public void propertyChange(final PropertyChangeEvent evt) {
+//        if (TurnQueue.END_OF_TURN.equals(evt.getPropertyName())) {
+//            counterAttackCounter = 1;
+//        }
+//    }
+
+    protected void restoreCurrentHpToMax() {
+        currentHp = stats.getMaxHp();
+    }
+
+    public String getName() {
+        return stats.getName();
+    }
+
+    public int getHexSize() {return stats.getHexSize();}
+
+    public int getShotRange() {
+        return stats.getShotRange();
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        //todo shouldn't be empty
+    }
+
+    public boolean checkIfAlive(MapObjectIf defender) {
+        return defender.getCurrentHp() > 0;
+    }
+
+    public static class Builder {
+        private int amount = 1;
+        private WarMachineDamageCalculatorIF calculator = new WarMachineDamageCalculator();
+        private FirstAidTentIf HPcalculator = new WarMachineHealPointsCalculator();
+        private WarMachineStatisticIf statistic;
+
+        public Builder statistic(final WarMachineStatisticIf aStatistic) {
+            statistic = aStatistic;
+            return this;
+        }
+
+        public Builder amount(final int aAmount) {
+            amount = aAmount;
+            return this;
+        }
+
+        Builder calculator(final WarMachineDamageCalculatorIF aCalc) {
+            calculator = aCalc;
+            return this;
+        }
+
+        public WarMachine build() { return new WarMachine(statistic,
+                calculator,
+                HPcalculator,
+                amount); }
+    }
+
+    @Override
+    public String toString() {
+        return getName() + System.lineSeparator() + getCurrentHp();
+    }
+}

--- a/battle-model/src/main/java/pl/psi/warmachines/WarMachineDamageCalculator.java
+++ b/battle-model/src/main/java/pl/psi/warmachines/WarMachineDamageCalculator.java
@@ -1,0 +1,107 @@
+package pl.psi.warmachines;
+
+import WarMachines.WarMachineStatistic;
+import pl.psi.MapObjectIf;
+
+public class WarMachineDamageCalculator implements WarMachineDamageCalculatorIF {
+    public int calculateDamage(WarMachine aAttacker, MapObjectIf aDefender) throws Exception {
+        int damage;
+        if (aAttacker.getStats().equals(WarMachineStatistic.BALLISTA)){
+            //todo real hero artillery skill value and heroAttack value must be used
+            damage = calculateDamageFromBallista(3, 0, 3);
+        } else if (aAttacker.getStats().equals(WarMachineStatistic.CATAPULT)) {
+            //todo real hero ballistics skill value must be used
+            damage = calculateFirstShotDamageFromCatapult(0) + calculateSecondShotDamageFromCatapult(0);
+        } else{
+            throw new Exception("Only ballista and catapult can apply damage");
+        }
+        return damage;
+    }
+
+    // Method uses given attack value to calculate damage which will be applied on creature attacked by ballista
+    private int calculateDamageFromBallista(int heroAttack, int heroArtillerySkill, int heroArcherySkill){
+
+        //Base damage (heroAttackPoints = 0)
+        float lowerBoundary = 2;
+        float upperBoundary = 3;
+
+    /*
+    If hero has archery skill - this has to be calculated before the added bonus of artillery skill AND attack skill
+    As opposed to slightly misleading in-game skill description Archery increases the base damage of ranged attacks
+    by 10%, 25% or 50% depending on the level of the skill. This does not mean that the total damage (final damage)
+    is necessarily increased by the same percentage, as it might also be increased by other factors,
+    such as high Attack skill - compare damage formula.
+    */
+        if (heroArcherySkill == 1){
+            lowerBoundary *= 1.1;
+            upperBoundary *= 1.1;
+        } else if (heroArcherySkill == 2) {
+            lowerBoundary *= 1.25;
+            upperBoundary *= 1.25;
+        } else if(heroArcherySkill == 3){
+            lowerBoundary *= 1.5;
+            upperBoundary *= 1.5;
+        }
+        lowerBoundary *= (heroAttack + 1);
+        upperBoundary *= (heroAttack + 1);
+        float damage = (float) getRandomNumber(lowerBoundary, upperBoundary);
+        damage = Math.round(damage);
+
+        //If hero has artillery skill
+        double probability = Math.random();
+        if (heroArtillerySkill == 1 && probability >= 0.5){
+            damage *= 2;
+        } else if (heroArtillerySkill == 2) {
+            if (probability >= 0.25){
+                damage *=4;
+            } else {
+                damage *= 2;
+            }
+        } else if(heroArtillerySkill == 3){
+            damage *= 4;
+        }
+        return (int) damage;
+    }
+
+    private double getRandomNumber(float min, float max) {
+        return ((Math.random() * (max - min)) + min);
+    }
+
+    private int calculateFirstShotDamageFromCatapult(int heroBallisticSkills){
+        double probability = Math.random();
+        int damage;
+        switch (heroBallisticSkills){
+            case 0:
+                if (probability <= 0.1){
+                    damage = 0;
+                } else if (probability <= 0.4) {
+                    damage = 2;
+                } else {
+                    damage = 1;
+                }
+                break;
+            case 1:
+            case 2:
+                if (probability <= 0.5){
+                    damage = 1;
+                } else {
+                    damage = 2;
+                }
+                break;
+            case 3:
+                damage = 2;
+                break;
+            default:
+                damage = 0;
+        }
+        return damage;
+    }
+
+    private int calculateSecondShotDamageFromCatapult(int heroBallisticSkills) {
+        int damage = 0;
+        if (heroBallisticSkills >= 2){
+            damage = calculateFirstShotDamageFromCatapult(heroBallisticSkills);
+        }
+        return damage;
+    }
+}

--- a/battle-model/src/main/java/pl/psi/warmachines/WarMachineDamageCalculatorIF.java
+++ b/battle-model/src/main/java/pl/psi/warmachines/WarMachineDamageCalculatorIF.java
@@ -1,0 +1,7 @@
+package pl.psi.warmachines;
+
+import pl.psi.MapObjectIf;
+
+public interface WarMachineDamageCalculatorIF {
+    int calculateDamage(WarMachine aAttacker, MapObjectIf aDefender) throws Exception;
+}

--- a/battle-model/src/main/java/pl/psi/warmachines/WarMachineHealPointsCalculator.java
+++ b/battle-model/src/main/java/pl/psi/warmachines/WarMachineHealPointsCalculator.java
@@ -1,0 +1,33 @@
+package pl.psi.warmachines;
+
+import WarMachines.WarMachineStatistic;
+import pl.psi.MapObjectIf;
+
+public class WarMachineHealPointsCalculator implements FirstAidTentIf{
+
+    public int calculateHealPoint(WarMachine aAttacker, MapObjectIf aComrade, int currentHP) throws Exception {
+
+        int hp;
+        if (aAttacker.getStats().equals(WarMachineStatistic.FIRST_AID_TENT)){
+            //todo real hero first aid skill value must be used
+            hp = calculateHealPoints(0, currentHP);
+        } else{
+            throw new Exception("Only FirstAidTent can heal");
+        }
+        return hp;
+    }
+
+    private int heroFirstAidSkill;
+    protected int calculateHealPoints(int heroFirstAidSkill, int currentHp){
+        switch (heroFirstAidSkill){
+            case 0: currentHp += calculateUpperBoundary(25); break;
+            case 1: currentHp += calculateUpperBoundary(50); break;
+            case 2: currentHp += calculateUpperBoundary(75); break;
+            case 3: currentHp += calculateUpperBoundary(100); break;
+        }
+        return currentHp;
+    }
+    private int calculateUpperBoundary(int upperBoundary){
+        return (int) (Math.random() * upperBoundary) + 1;
+    }
+}

--- a/battle-model/src/test/java/pl/psi/BoardTest.java
+++ b/battle-model/src/test/java/pl/psi/BoardTest.java
@@ -18,13 +18,13 @@ class BoardTest
             .moveRange( 5 )
             .build() )
             .build();
-        final List< Creature > c1 = List.of( creature );
-        final List< Creature > c2 = List.of();
-        final Board board = new Board( c1, c2 );
+//        final List< Creature > c1 = List.of( creature );
+//        final List< Creature > c2 = List.of();
+        final Board board = new Board( List.of(creature), List.of() );
 
         board.move( creature, new Point( 3, 3 ) );
 
-        assertThat( board.getCreature( new Point( 3, 3 ) )
+        assertThat( board.getMapObject( new Point( 3, 3 ) )
             .isPresent() ).isTrue();
     }
 

--- a/battle-model/src/test/java/pl/psi/GameEngineTest.java
+++ b/battle-model/src/test/java/pl/psi/GameEngineTest.java
@@ -2,9 +2,11 @@ package pl.psi;
 
 import java.util.List;
 
+import WarMachines.WarMachineStatistic;
 import org.junit.jupiter.api.Test;
 
 import pl.psi.creatures.CastleCreatureFactory;
+import pl.psi.warmachines.WarMachine;
 
 /**
  * TODO: Describe this class (The first line - until the first dot - will interpret as the brief description).
@@ -16,8 +18,8 @@ public class GameEngineTest
     {
         final CastleCreatureFactory creatureFactory = new CastleCreatureFactory();
         final GameEngine gameEngine =
-            new GameEngine( new Hero( List.of( creatureFactory.create( 1, false, 5 ) ) ),
-                new Hero( List.of( creatureFactory.create( 1, false, 5 ) ) ) );
+            new GameEngine(new Hero( List.of( creatureFactory.create( 1, false, 5 )), List.of(new WarMachine.Builder().statistic(WarMachineStatistic.CATAPULT).amount(1).build())),
+                    new Hero(List.of( creatureFactory.create( 1, false, 5 )), List.of(new WarMachine.Builder().statistic(WarMachineStatistic.BALLISTA).amount(1).build())));
 
         gameEngine.attack( new Point( 1, 1 ) );
     }

--- a/battle-model/src/test/java/pl/psi/NewTurnQueuePrototypeTest.java
+++ b/battle-model/src/test/java/pl/psi/NewTurnQueuePrototypeTest.java
@@ -1,42 +1,16 @@
 package pl.psi;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-
-import java.util.List;
-
+import pl.psi.warmachines.WarMachine;
 import WarMachines.WarMachineStatistic;
 import WarMachines.WarMachineStats;
 import org.junit.jupiter.api.Test;
 
-import pl.psi.creatures.Creature;
-import pl.psi.creatures.CreatureStats;
-import pl.psi.warmachines.WarMachine;
+import java.util.List;
 
-class TurnQueueTest
-{
-    @Test
-    void shouldAddPawnsCorrectly()
-    {
-        final Creature creature1 = new Creature.Builder().statistic( CreatureStats.builder()
-            .build() )
-            .build();
-        final Creature creature2 = new Creature.Builder().statistic( CreatureStats.builder()
-            .build() )
-            .build();
-        final Creature creature3 = new Creature.Builder().statistic( CreatureStats.builder()
-            .build() )
-            .build();
-        final TurnQueue turnQueue = new TurnQueue( List.of( creature1, creature2 ), List.of( creature3 ) );
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-        assertEquals( turnQueue.getCurrentMapObject(), creature1 );
-        turnQueue.next();
-        assertEquals( turnQueue.getCurrentMapObject(), creature2 );
-        turnQueue.next();
-        assertEquals( turnQueue.getCurrentMapObject(), creature3 );
-        turnQueue.next();
-        assertEquals( turnQueue.getCurrentMapObject(), creature1 );
-    }
+class NewTurnQueuePrototypeTest {
 
     final WarMachine warMachine1 = new WarMachine.Builder().statistic(WarMachineStats.builder().build()).build();
     final WarMachine warMachine2 = new WarMachine.Builder().statistic(WarMachineStats.builder().build()).build();
@@ -45,13 +19,13 @@ class TurnQueueTest
     TurnQueue turnQueue = new TurnQueue(List.of(warMachine1, warMachine2), List.of(warMachine3));
 
     @Test
-    void getCurrentMapObject() {
+    void getCurrentWarMachine() {
         assertEquals(turnQueue.getCurrentMapObject(), warMachine1);
     }
 
 
     @Test
-    void shouldGoToNextMapObject() {
+    void shouldGoToNextWarMachine() {
         assertEquals(turnQueue.getCurrentMapObject(), warMachine1);
 
         turnQueue.next();
@@ -68,7 +42,7 @@ class TurnQueueTest
     }
 
     @Test
-    void removeMapObject() {
+    void removeWarMachine() {
         WarMachine ballista1 = new WarMachine.Builder().statistic(WarMachineStatistic.BALLISTA).build();
         WarMachine ballista2 = new WarMachine.Builder().statistic(WarMachineStatistic.BALLISTA).build();
         WarMachine catapult = new WarMachine.Builder().statistic(WarMachineStatistic.CATAPULT).build();

--- a/battle-model/src/test/java/pl/psi/NewTurnQueueWithWarMachinesTest.java
+++ b/battle-model/src/test/java/pl/psi/NewTurnQueueWithWarMachinesTest.java
@@ -1,0 +1,66 @@
+//package pl.psi;
+//
+//import pl.psi.warmachines.WarMachine;
+//import WarMachines.WarMachineStats;
+//import org.junit.jupiter.api.Test;
+//import pl.psi.creatures.Creature;
+//import pl.psi.creatures.CreatureStats;
+//
+//import java.util.List;
+//
+//import static org.junit.jupiter.api.Assertions.*;
+//
+//class NewTurnQueueWithWarMachinesTest {
+//
+//    final Creature creature1 = new Creature.Builder().statistic( CreatureStats.builder()
+//                    .build() )
+//            .build();
+//    final Creature creature2 = new Creature.Builder().statistic( CreatureStats.builder()
+//                    .build() )
+//            .build();
+//    final Creature creature3 = new Creature.Builder().statistic( CreatureStats.builder()
+//                    .build() )
+//            .build();
+//
+//    final WarMachine warMachine1 = new WarMachine.Builder().statistic(WarMachineStats.builder().build()).build();
+//    final WarMachine warMachine2 = new WarMachine.Builder().statistic(WarMachineStats.builder().build()).build();
+//    final WarMachine warMachine3 = new WarMachine.Builder().statistic(WarMachineStats.builder().build()).build();
+//    final WarMachine warMachine4 = new WarMachine.Builder().statistic(WarMachineStats.builder().build()).build();
+//    NewTurnQueueWithWarMachines newTurnQueueWithWarMachines = new NewTurnQueueWithWarMachines( List.of( creature1, creature2 ), List.of( creature3 ), List.of(warMachine1, warMachine2), List.of(warMachine3, warMachine4) );
+//
+//    @Test
+//    void getCurrentCreature() {
+//        assertEquals(newTurnQueueWithWarMachines.getCurrentCreature(), creature1);
+//    }
+//
+//    @Test
+//    void getCurrentWarMachine() {
+//        assertEquals(newTurnQueueWithWarMachines.getCurrentWarMachine(), warMachine1);
+//    }
+//
+//    @Test
+//    void shouldGoToNextCreatureAndWarMachine() {
+//        assertEquals(newTurnQueueWithWarMachines.getCurrentCreature(), creature1);
+//        assertEquals(newTurnQueueWithWarMachines.getCurrentWarMachine(), warMachine1);
+//
+//        newTurnQueueWithWarMachines.next();
+//
+//        assertEquals(newTurnQueueWithWarMachines.getCurrentCreature(), creature2);
+//        assertEquals(newTurnQueueWithWarMachines.getCurrentWarMachine(), warMachine2);
+//
+//        newTurnQueueWithWarMachines.next();
+//
+//        assertEquals(newTurnQueueWithWarMachines.getCurrentCreature(), creature3);
+//        assertEquals(newTurnQueueWithWarMachines.getCurrentWarMachine(), warMachine3);
+//
+//        newTurnQueueWithWarMachines.next();
+//
+//        assertTrue(newTurnQueueWithWarMachines.getCurrentCreature() == null);
+//        assertEquals(newTurnQueueWithWarMachines.getCurrentWarMachine(), warMachine4);
+//
+//        newTurnQueueWithWarMachines.next();
+//
+//        assertEquals(newTurnQueueWithWarMachines.getCurrentCreature(), creature1);
+//        assertEquals(newTurnQueueWithWarMachines.getCurrentWarMachine(), warMachine1);
+//    }
+//}

--- a/battle-model/src/test/java/pl/psi/WarMachines/AmmoCartWarMachineTest.java
+++ b/battle-model/src/test/java/pl/psi/WarMachines/AmmoCartWarMachineTest.java
@@ -1,0 +1,25 @@
+//package pl.psi.WarMachines;
+//
+//import org.junit.jupiter.api.Test;
+//
+//import static org.junit.jupiter.api.Assertions.*;
+//
+//class AmmoCartWarMachineTest {
+//
+//    AmmoCartWarMachine ammoCartWarMachine = new AmmoCartWarMachine();
+//
+//    @Test
+//    void getAmmoCartHP() {
+//        assertEquals(100, ammoCartWarMachine.getAmmoCartHP());
+//    }
+//
+//    @Test
+//    void getAmmoCartCost() {
+//        assertEquals(1000, ammoCartWarMachine.getAmmoCartCost());
+//    }
+//
+//    @Test
+//    void getAmmoCartDefence() {
+//        assertEquals(5, ammoCartWarMachine.getAmmoCartDefence());
+//    }
+//}

--- a/battle-model/src/test/java/pl/psi/WarMachines/BallistaMachineTestArcheryAndArtillerySkills.java
+++ b/battle-model/src/test/java/pl/psi/WarMachines/BallistaMachineTestArcheryAndArtillerySkills.java
@@ -1,0 +1,112 @@
+//package pl.psi.WarMachines;
+//
+//import org.junit.jupiter.api.Test;
+//import static org.junit.jupiter.api.Assertions.*;
+//
+//public class BallistaMachineTestArcheryAndArtillerySkills {
+//
+//    @Test
+//    void calculateDamageFromBallistaWithNoArcherySkill() {
+//        int heroAttackPoints = 5;
+//        BallistaMachine ballistaMachine = new BallistaMachine(heroAttackPoints,0,0,0);
+//        int damage = ballistaMachine.getBallistaDamage();
+//        System.out.println("Damage: " + damage);
+//        assertFalse(damage < 2 * (heroAttackPoints + 1));
+//        assertFalse(damage > 3 * (heroAttackPoints + 1));
+//    }
+//
+//    // 50% base dmg boost
+//    // lowerBoundary = 3 ; upperBoundary = 4.5; but the random dmg number is rounded to the nearest value
+//
+//    @Test
+//    void calculateDamageFromBallistaWithArcherySkillLvl3() {
+//        int heroArcherySkill = 3;
+//        BallistaMachine ballistaMachine = new BallistaMachine(0,0,0,heroArcherySkill);
+//        int damage = ballistaMachine.getBallistaDamage();
+//        System.out.println("Damage: " + damage);
+//        assertTrue(damage >=  Math.round(2*1.5));
+//        assertTrue(damage <= Math.round(3*1.5));
+//    }
+//
+//    // 25% base dmg boost
+//    // lowerBoundary = 2.5 ; upperBoundary = 3.75; but the random dmg number is rounded to the nearest value
+//
+//    @Test
+//    void calculateDamageFromBallistaWithArcherySkillLvl2() {
+//        int heroArcherySkill = 2;
+//        BallistaMachine ballistaMachine = new BallistaMachine(0,0,0,heroArcherySkill);
+//        int damage = ballistaMachine.getBallistaDamage();
+//        System.out.println("Damage: " + damage);
+//        assertTrue(damage >= Math.round(2*1.25));
+//        assertTrue(damage <= Math.round(3*1.25));
+//    }
+//
+//    // 10% base dmg boost
+//    // lowerBoundary = 2.2 ; upperBoundary = 3.3; but the random dmg number is rounded to the nearest value
+//
+//    @Test
+//    void calculateDamageFromBallistaWithArcherySkillLvl1() {
+//        int heroArcherySkill = 1;
+//        BallistaMachine ballistaMachine = new BallistaMachine(0,0,0,heroArcherySkill);
+//        int damage = ballistaMachine.getBallistaDamage();
+//        System.out.println("Damage: " + damage);
+//        assertTrue(damage >= Math.round(2*1.1));
+//        assertTrue(damage <= Math.round(3*1.1));
+//    }
+//
+//    //tests for different skill lvl combinations
+//    @Test
+//    void calculateDamageFromBallistaWithArcheryLvl1AndArtilleryLvl1() {
+//        int heroArcherySkill = 1;
+//        int heroArtillerySkill = 1;
+//        BallistaMachine ballistaMachine = new BallistaMachine(0,0,heroArtillerySkill,heroArcherySkill);
+//        int damage = ballistaMachine.getBallistaDamage();
+//        System.out.println("Damage: " + damage);
+//        assertTrue((damage >= Math.round(2*1.1) && damage <= Math.round(3*1.1)) ||
+//                damage >= Math.round(2*2*1.1) && damage <= Math.round(3*2*1.1));
+//    }
+//
+//    @Test
+//    void calculateDamageFromBallistaWithArcheryLvl3AndArtilleryLvl1() {
+//        int heroArcherySkill = 3;
+//        int heroArtillerySkill = 1;
+//        BallistaMachine ballistaMachine = new BallistaMachine(0,0,heroArtillerySkill,heroArcherySkill);
+//        int damage = ballistaMachine.getBallistaDamage();
+//        System.out.println("Damage: " + damage);
+//        assertTrue((damage >= Math.round(2*1.5) && damage <= Math.round(3*1.5)) ||
+//                damage >= Math.round(2*2*1.5) && damage <= Math.round(3*2*1.5));
+//    }
+//
+//    @Test
+//    void calculateDamageFromBallistaWithArcheryLvl3AndArtilleryLvl3() {
+//        int heroArcherySkill = 3;
+//        int heroArtillerySkill = 3;
+//        BallistaMachine ballistaMachine = new BallistaMachine(0,0,heroArtillerySkill,heroArcherySkill);
+//        int damage = ballistaMachine.getBallistaDamage();
+//        System.out.println("Damage: " + damage);
+//        assertTrue( damage >= Math.round(4*2*1.5) && damage <= Math.round(4*3*1.5));
+//    }
+//
+//    @Test
+//    void calculateDamageFromBallistaWithArcheryLvl3AndArtilleryLvl2() {
+//        int heroArcherySkill = 3;
+//        int heroArtillerySkill = 2;
+//        BallistaMachine ballistaMachine = new BallistaMachine(0,0,heroArtillerySkill,heroArcherySkill);
+//        int damage = ballistaMachine.getBallistaDamage();
+//        System.out.println("Damage: " + damage);
+//        assertTrue( damage >= Math.round(4*2*1.5) && damage <= Math.round(4*3*1.5) ||
+//                damage >= Math.round(2*2*1.5) && damage <= Math.round(2*3*1.5));
+//    }
+//
+//    @Test
+//    void calculateDamageFromBallistaWithArcheryLvl2AndArtilleryLvl2() {
+//        int heroArcherySkill = 2;
+//        int heroArtillerySkill = 2;
+//        BallistaMachine ballistaMachine = new BallistaMachine(0,0,heroArtillerySkill,heroArcherySkill);
+//        int damage = ballistaMachine.getBallistaDamage();
+//        System.out.println("Damage: " + damage);
+//        assertTrue( damage >= Math.round(4*2*1.25) && damage <= Math.round(4*3*1.25) ||
+//                damage >= Math.round(2*2*1.25) && damage <= Math.round(2*3*1.25));
+//    }
+//
+//}

--- a/battle-model/src/test/java/pl/psi/WarMachines/BallistaMachineTestArtillerySkill.java
+++ b/battle-model/src/test/java/pl/psi/WarMachines/BallistaMachineTestArtillerySkill.java
@@ -1,0 +1,98 @@
+//package pl.psi.WarMachines;
+//
+//import org.junit.jupiter.api.Test;
+//
+//import static org.junit.jupiter.api.Assertions.*;
+//
+//class BallistaMachineTestArtillerySkill {
+//    BallistaMachine ballistaMachine = new BallistaMachine();
+//    @Test
+//    void calculateDamageFromBallista() {
+//        int attack = 5;
+//        int damage = ballistaMachine.calculateDamageFromBallista(attack);
+//        assertTrue(2 * (attack + 1) <= damage && damage <= 3 * (attack + 1));
+//        assertFalse(damage < 2 * (attack + 1));
+//        assertFalse(damage > 3 * (attack + 1));
+//        assertFalse(damage > 100 * attack);
+//    }
+//
+//    @Test
+//    void calculateAverageDamageFromBallista(){
+//        int attack = 25;
+//        int expectedDamage = (2 * (attack + 1) + 3 * (attack + 1)) / 2;
+//        int averageDamage = 0;
+//        int iterations = 10000000;
+//        for (int i = 0; i < iterations; i++) {
+//            averageDamage += ballistaMachine.calculateDamageFromBallista(attack);
+//        }
+//        averageDamage /= iterations;
+//        averageDamage = Math.round(averageDamage);
+//
+//        assertEquals(expectedDamage, averageDamage);
+//        assertEquals(65,averageDamage);
+//    }
+//
+//    @Test
+//    void calculateDamageFromBallistaWithArtillerySkillLvlOne(){
+//        int heroAttackPoints = 10;
+//        int heroArtillerySkill = 1;
+//        BallistaMachine ballistaMachine2 = new BallistaMachine(heroAttackPoints,0,heroArtillerySkill,0);
+//        int damage = ballistaMachine2.getBallistaDamage();
+//        System.out.println("Damage: " + damage);
+//        assertTrue(damage >= Math.round(2*(heroAttackPoints + 1)) && damage <= Math.round(3*(heroAttackPoints + 1)) ||
+//                damage >= Math.round(2*2*(heroAttackPoints + 1)) && damage <= Math.round(3*2*(heroAttackPoints + 1)));
+//    }
+//    @Test
+//    void calculateDamageFromBallistaWithArtillerySkillLvlTwo(){
+//        int heroAttackPoints = 10;
+//        int heroArtillerySkill = 2;
+//        BallistaMachine ballistaMachine2 = new BallistaMachine(heroAttackPoints,0,heroArtillerySkill,0);
+//        int damage = ballistaMachine2.getBallistaDamage();
+//        System.out.println("Damage: " + damage);
+//        System.out.println("Lower: " + 2 * 2 * (heroAttackPoints + 1));
+//        System.out.println("Upper: " + 4 * 3 * (heroAttackPoints + 1));
+//        assertTrue(damage >= Math.round(4*2*(heroAttackPoints + 1)) && damage <= Math.round(4*3*(heroAttackPoints + 1)) ||
+//                damage >= Math.round(2*2*(heroAttackPoints + 1)) && damage <= Math.round(2*3*(heroAttackPoints + 1)));
+//    }
+//    @Test
+//    void calculateDamageFromBallistaWithArtillerySkillLvlThree(){
+//        int heroAttackPoints = 10;
+//        int heroArtillerySkill = 3;
+//        BallistaMachine ballistaMachine2 = new BallistaMachine(heroAttackPoints,0,heroArtillerySkill,0);
+//        int damage = ballistaMachine2.getBallistaDamage();
+//        System.out.println("Damage: " + damage);
+//        System.out.println("Lower: " + 4 * 2 * (heroAttackPoints + 1));
+//        System.out.println("Upper: " + 4 * 3 * (heroAttackPoints + 1));
+//        assertTrue(4 * 2 * (heroAttackPoints + 1) <= damage &&
+//                damage <= 4 * 3 * (heroAttackPoints + 1));
+//    }
+//
+//    @Test
+//    void calculateAverageDamageFromBallistaWithArtillerySkills(){
+//        int heroAttackPoints = 15;
+//        int heroArtillerySkill = 2;
+//        int expectedDamage = 140;
+//
+//        float averageDamage = 0;
+//        int iterations = 10000;
+//        for (int i = 0; i < iterations; i++) {
+//            BallistaMachine ballistaMachine2 = new BallistaMachine(heroAttackPoints,0,heroArtillerySkill,0);
+//            averageDamage += ballistaMachine2.getBallistaDamage();
+//        }
+//        averageDamage /= iterations;
+//        System.out.println("Average damage: " + averageDamage);
+//        averageDamage = Math.round(averageDamage);
+//        assertEquals(expectedDamage, averageDamage);
+//    }
+//
+////    This is test for private method
+////    @Test
+////    void getRandomNumber() {
+////        int lowerBoundary = 1;
+////        int upperBoundary = 2;
+////        double randomNumber = ballistaMachine.getRandomNumber(lowerBoundary,upperBoundary);
+////        assertTrue((lowerBoundary <= randomNumber) && (randomNumber <= upperBoundary));
+////        assertFalse(randomNumber < lowerBoundary);
+////        assertFalse(randomNumber > upperBoundary);
+////    }
+//}

--- a/battle-model/src/test/java/pl/psi/WarMachines/CatapultMachineTest.java
+++ b/battle-model/src/test/java/pl/psi/WarMachines/CatapultMachineTest.java
@@ -1,0 +1,52 @@
+//package pl.psi.WarMachines;
+//
+//import org.junit.jupiter.api.Test;
+//
+//import static org.junit.jupiter.api.Assertions.*;
+//
+//class CatapultMachineTest {
+//
+//    CatapultMachine catapultMachine = new CatapultMachine(0);
+//
+//
+//
+//    @Test
+//    void getCatapultFirstShotDamage() {
+//        CatapultMachine catapultMachine0 = new CatapultMachine(0);
+//        CatapultMachine catapultMachine1 = new CatapultMachine(1);
+//        CatapultMachine catapultMachine2 = new CatapultMachine(2);
+//        CatapultMachine catapultMachine3 = new CatapultMachine(3);
+//
+//        int damage0 = catapultMachine0.getCatapultFirstShotDamage();
+//        assertTrue(0 <= damage0 && damage0 <= 2);
+//
+//        int damage1 = catapultMachine1.getCatapultFirstShotDamage();
+//        assertTrue(1 <= damage1 && damage1 <= 2);
+//
+//        int damage2 = catapultMachine2.getCatapultFirstShotDamage();
+//        assertTrue(1 <= damage2 && damage2 <= 2);
+//
+//        int damage3 = catapultMachine3.getCatapultFirstShotDamage();
+//        assertEquals(2, damage3);
+//    }
+//
+//    @Test
+//    void getCatapultSecondShotDamage() {
+//        CatapultMachine catapultMachine0 = new CatapultMachine(0);
+//        CatapultMachine catapultMachine1 = new CatapultMachine(1);
+//        CatapultMachine catapultMachine2 = new CatapultMachine(2);
+//        CatapultMachine catapultMachine3 = new CatapultMachine(3);
+//
+//        int damage0 = catapultMachine0.getCatapultSecondShotDamage();
+//        assertEquals(0, damage0);
+//
+//        int damage1 = catapultMachine1.getCatapultSecondShotDamage();
+//        assertEquals(0, damage1);
+//
+//        int damage2 = catapultMachine2.getCatapultSecondShotDamage();
+//        assertTrue(1 <= damage2 && damage2 <= 2);
+//
+//        int damage3 = catapultMachine3.getCatapultSecondShotDamage();
+//        assertEquals(2, damage3);
+//    }
+//}

--- a/battle-model/src/test/java/pl/psi/WarMachines/FirstAidTentMachineTest.java
+++ b/battle-model/src/test/java/pl/psi/WarMachines/FirstAidTentMachineTest.java
@@ -1,0 +1,44 @@
+//package pl.psi.WarMachines;
+//
+//import org.junit.jupiter.api.Test;
+//
+//import static org.junit.jupiter.api.Assertions.*;
+//
+//class FirstAidTentMachineTest {
+//
+//    FirstAidTentMachine tent = new FirstAidTentMachine();
+//
+//    @Test
+//    void calculateHealPointsFirstAidSkillLvlZero(){
+//        int currentHp = 100;
+//        int heroFirstAidSkill = 0;
+//        int HpAfterHeal = tent.calculateHealPoints(heroFirstAidSkill, currentHp);
+//
+//        assertTrue(HpAfterHeal >= 101 && HpAfterHeal <= 125);
+//    }
+//    @Test
+//    void calculateHealPointsFirstAidSkillLvlOne(){
+//        int currentHp = 100;
+//        int heroFirstAidSkill = 1;
+//        int HpAfterHeal = tent.calculateHealPoints(heroFirstAidSkill, currentHp);
+//
+//        assertTrue(HpAfterHeal >= 101 && HpAfterHeal <= 150);
+//    }
+//    @Test
+//    void calculateHealPointsFirstAidSkillLvlTwo(){
+//        int currentHp = 100;
+//        int heroFirstAidSkill = 2;
+//        int HpAfterHeal = tent.calculateHealPoints(heroFirstAidSkill, currentHp);
+//
+//        assertTrue(HpAfterHeal >= 101 && HpAfterHeal <= 175);
+//    }
+//    @Test
+//    void calculateHealPointsFirstAidSkillLvlThree(){
+//        int currentHp = 100;
+//        int heroFirstAidSkill = 3;
+//        int HpAfterHeal = tent.calculateHealPoints(heroFirstAidSkill, currentHp);
+//
+//        assertTrue(HpAfterHeal >= 101 && HpAfterHeal <= 200);
+//    }
+//
+//}

--- a/battle-model/src/test/java/pl/psi/WarMachines/WarMachineDamageCalculatorTest.java
+++ b/battle-model/src/test/java/pl/psi/WarMachines/WarMachineDamageCalculatorTest.java
@@ -1,0 +1,29 @@
+package pl.psi.WarMachines;
+
+import WarMachines.WarMachineStatistic;
+import org.junit.jupiter.api.Test;
+import pl.psi.warmachines.WarMachine;
+import pl.psi.warmachines.WarMachineDamageCalculator;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WarMachineDamageCalculatorTest {
+
+    WarMachineDamageCalculator warMachineDamageCalculator = new WarMachineDamageCalculator();
+    WarMachine ballista = new WarMachine.Builder().statistic(WarMachineStatistic.BALLISTA).amount(1).build();
+    WarMachine catapult = new WarMachine.Builder().statistic(WarMachineStatistic.CATAPULT).amount(1).build();
+    @Test
+    void calculateDamage() throws Exception {
+        int damage = warMachineDamageCalculator.calculateDamage(ballista, catapult);
+        assertTrue(0 < damage);
+        System.out.println("First calculation for damage value: " + damage);
+        int averageDamage = 0;
+
+        for (int i = 0; i < 1000000; i++) {
+            averageDamage += warMachineDamageCalculator.calculateDamage(ballista, catapult);
+        }
+
+        averageDamage /= 1000000;
+        assertEquals(15, averageDamage);
+    }
+}

--- a/battle-model/src/test/java/pl/psi/WarMachines/WarMachineTest.java
+++ b/battle-model/src/test/java/pl/psi/WarMachines/WarMachineTest.java
@@ -1,0 +1,68 @@
+package pl.psi.WarMachines;
+
+import WarMachines.WarMachineStatistic;
+import org.junit.jupiter.api.Test;
+import pl.psi.warmachines.WarMachine;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WarMachineTest {
+
+//    @Test
+//    void attackTEST() throws Exception {
+//        int avgDamage = 0;
+//        for (int i = 0; i < 10000; i++) {
+//            WarMachine ballista = new WarMachine.Builder().statistic(WarMachineStatistic.BALLISTA).build();
+//            avgDamage += ballista.attack(new WarMachine());
+//        }
+//        avgDamage /= 10000;
+//        assertEquals(250, avgDamage);
+//        WarMachine ammoCart = new WarMachine.Builder().statistic(WarMachineStatistic.AMMO_CART).build();
+//        try {
+//            ammoCart.attack(new WarMachine());
+//        } catch (Exception e){
+//            System.err.println(e);
+//        }
+//        WarMachine catapult = new WarMachine.Builder().statistic(WarMachineStatistic.CATAPULT).build();
+//        int catapultDamage = catapult.attack(new WarMachine());
+//        assertTrue(0 <= catapultDamage && catapultDamage <= 2);
+//        int iteration = 0;
+//        while (true){
+//            iteration++;
+//            catapultDamage = catapult.attack(new WarMachine());
+//            if (catapultDamage == 2){
+//                System.out.println("Catapult damage: " + catapultDamage);
+//                System.out.println("Number of iterations: " + iteration);
+//                break;
+//            }
+//        }
+//    }
+
+    @Test
+    void shouldLoseHP() throws Exception {
+        WarMachine ammoCart = new WarMachine.Builder().statistic(WarMachineStatistic.AMMO_CART).amount(1).build();
+        assertEquals(100, ammoCart.getCurrentHp());
+        WarMachine ballista = new WarMachine.Builder().statistic(WarMachineStatistic.BALLISTA).amount(1).build();
+        ballista.attack(ammoCart);
+        assertTrue(ammoCart.getCurrentHp() < 100);
+        System.out.println("Ammo cart hp after first attack: " + ammoCart.getCurrentHp());
+        ballista.attack(ammoCart);
+        System.out.println("Ammo cart hp after second attack: " + ammoCart.getCurrentHp());
+    }
+
+    @Test
+    void getCurrentHp() throws Exception {
+        WarMachine ballista = new WarMachine.Builder().statistic(WarMachineStatistic.BALLISTA).build();
+        WarMachine catapult = new WarMachine.Builder().statistic(WarMachineStatistic.CATAPULT).build();
+        assertEquals(1000, catapult.getCurrentHp());
+
+        ballista.attack(catapult);
+        assertTrue(catapult.getCurrentHp() < 1000);
+
+        for (int i = 0; i < 1000; i++) {
+            ballista.attack(catapult);
+        }
+
+        assertEquals(0, catapult.getCurrentHp());
+    }
+}

--- a/hero-common/pom.xml
+++ b/hero-common/pom.xml
@@ -20,6 +20,12 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/hero-common/src/main/java/WarMachines/WarMachineStatistic.java
+++ b/hero-common/src/main/java/WarMachines/WarMachineStatistic.java
@@ -1,0 +1,56 @@
+package WarMachines;
+
+import com.google.common.collect.Range;
+
+import lombok.Getter;
+
+@Getter
+public enum WarMachineStatistic implements WarMachineStatisticIf
+{
+    AMMO_CART( "Ammo Cart", 0, 100, 0, 5, Range.closed(0,0), 1, 1,
+            "Useful to have for long battles if you are using range attackers who run out of ammunition. Another subtle use for the ammo cart is that it can take one extra hit away from a powerful chain lightning - it will be destroyed of course.",
+            false ), //
+    BALLISTA( "Ballista", 10, 250, 24, 10, Range.closed(8,12), 5, 2,
+            "Ballista is affected by hero's attack still, and unless your hero has a strong attack AND Artillery secondary skill, ballista will not do much damage, buy 2500 gold worth of creatures instead. If you are going for Artillery secondary skill, keep in mind that ballista only has 250 hit points, and once destroyed, the skill will remain useless for the rest of the battle. That is why heroes should choose Offense, Armourer, etc over Artillery. Note: without Artillery secondary skill, ballista will shoot without your control.",
+            false ), //
+    FIRST_AID_TENT( "First Aid Tent", 0, 75, 0, 0, Range.closed(0,0), 1, 2,
+            "Heals a small amount of hit points to a top creature in one of your stacks every round. The effect is very weak. First Aid skill gives you control over the tent and makes it heal more hit points, but the tent is extremely easy to destroy, rendering your First Aid skill useless for the rest of the battle - see note on Artillery above. The tent, however, can save you losing a few high-level creatures by topping up their hit points every round.",
+            false ), //
+    CATAPULT( "Catapult", 0, 1000, 24, 10, Range.closed(0,0), 1, 2,
+            "Every hero has one all the time. Catapult is affected by Balistics skill, which unlike other war machine skills is very important to learn. Catapult is durable and comes under your control as you deveop Ballistics. If you are under seige and have powerful spells, destroy the enemy catapult so you can keep your walls and archer towers, turning the tides of battle in your favour. Ballistics secondary skills is essential for towns like Fortress who lack strong flyers and shooters, they must break through the drawbridge before enemy shooters have a good go at them.",
+            false ); //
+
+
+    private final String name;
+
+    private final int attack; //counterattack?
+    private final int maxHp;
+    private final int shotRange;
+    private final int armor;
+    private final Range<Integer> damage;
+    private final int tier;
+    private final int hexSize;
+    private final String description;
+    private final boolean isUpgraded;
+    
+    WarMachineStatistic(final String aName, final int aAttack, final int aMaxHp,
+                        final int aShotRange, final int aArmor, final Range<Integer> aDamage, final int aTier, final int aHexSize,
+                        final String aDescription, final boolean aIsUpgraded )
+    {
+        name = aName;
+        attack = aAttack;
+        maxHp = aMaxHp;
+        shotRange = aShotRange;
+        armor = aArmor;
+        damage = aDamage;
+        tier = aTier;
+        hexSize = aHexSize;
+        description = aDescription;
+        isUpgraded = aIsUpgraded;
+    }
+
+    String getTranslatedName()
+    {
+        return name;
+    }
+}

--- a/hero-common/src/main/java/WarMachines/WarMachineStatisticIf.java
+++ b/hero-common/src/main/java/WarMachines/WarMachineStatisticIf.java
@@ -1,0 +1,16 @@
+package WarMachines;
+
+import com.google.common.collect.Range;
+
+public interface WarMachineStatisticIf {
+    String getName();
+    int getAttack();
+    int getArmor();
+    int getMaxHp();
+    int getShotRange();
+    Range< Integer > getDamage();
+    int getTier();
+    String getDescription();
+    boolean isUpgraded();
+    int getHexSize();
+}

--- a/hero-common/src/main/java/WarMachines/WarMachineStats.java
+++ b/hero-common/src/main/java/WarMachines/WarMachineStats.java
@@ -1,0 +1,20 @@
+package WarMachines;
+
+import com.google.common.collect.Range;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class WarMachineStats implements WarMachineStatisticIf{
+    private final String name;
+    private final int attack;
+    private final int armor;
+    private final int maxHp;
+    private final int shotRange;
+    private final Range< Integer > damage;
+    private final int tier;
+    private final String description;
+    private final boolean isUpgraded;
+    private final int hexSize;
+}


### PR DESCRIPTION
* Created BallistaMachine class and test

* Update [BallistaMachineTest.java](http://ballistamachinetest.java/)

* Basic WarMachineClass

* Tests and new turn queue

Updated tests for ballista machine and prepared foundation for new turn queue

* Tests for new turn queue and updates for ballista

The BallistaMachine class now has new fields and an updated damage calculator. The calculator now checks whether a hero has an artillery skill.

* Updated damage calculator for ballista

* Created CatapultMachine class

* WarMachines (Ballista) calculator separeted

* Revert "WarMachines (Ballista) calculator separeted"

This reverts commit 79cdd0e42dcac676aa5acd07ae9ffdf999e51b55.

* More tests for Ballista

* Tests for NewTurnQueue updated

* Ballista test update

* basic FirstAidTent and tests

* WarMachineStatistic changes

* Revert "WarMachineStatistic changes"

This reverts commit 857820aa07b9fc130b42badc6799bc0e7b15c498.

* Revert "Revert "WarMachineStatistic changes""

This reverts commit 61f79c8e16e1bdccccbdb563622dc8471c7e2cdc.

* WarMachineStatistic changes

* tidying up

* AmmoCartWarMachine and renaming

Created class AmmoCartWarMachine and renamed classes for ballista and catapult

* Restored old names

Because of conflict, restored old names

* Calculate damage during attack

Prepared foundation for calculating damage during an attack. Commented unnecessary tests

* Added artillery skill dmg calculation

* Tests for Ballista's damage calculation with archery and artillery skills

* More artillery + archery tests

* Fixed ballista Artillery tests

* Now war machines can apply damage

* Delete [CatapultMachineTest.java](http://catapultmachinetest.java/)

* Revert "Delete [CatapultMachineTest.java](http://catapultmachinetest.java/)"

This reverts commit 05b398b33cc2127a06f8a06359372d6e89de45da.

* Delete [CatapultMachineTest.java](http://catapultmachinetest.java/)

* Revert "Delete [CatapultMachineTest.java](http://catapultmachinetest.java/)"

This reverts commit 71735ef0eb1b00118aa43808e8772d35f784caa4.

* Update [CatapultMachineTest.java](http://catapultmachinetest.java/)

Changes to avoid merge conflict

* War machines were added to the GUI prototype. Now one war machine can attack another.

* Comments

* Comments

* Revert "Comments"

This reverts commit 41b0eb4d456e3f9684a4f9eefa6d0a90caa05cc3.

* NewHeroPrototype has both warmachines and creatures - still not visible in GUI

* Revert "NewHeroPrototype has both warmachines and creatures - still not visible in GUI"

This reverts commit 09ec663aa908c429e136a3e38a3f29cf76c68667.

* Adding creatures to GUI - an idea of implementation

* Revert "Adding creatures to GUI - an idea of implementation"

This reverts commit 0c3deadc329ba4c7315ebb5b4bc000be12e1c816.

* Create [MapObjectIf.java](http://mapobjectif.java/)

* Added possibility to beat war machine. This way you can remove the war machine from the board and queue.

* FirstAidTent Heal method

* Created unified board and unified turn queue for war machines and creatures.

* FirstAidTent Heal method continue

* FirstAidTent Heal method works

* Bring Heros back home :)

* Creatures can move again

* Bring Heros back home - repair small conflicts

* Changes from prototype classes are now in original classes

* Code refactoring